### PR TITLE
Added functionality to specifically respond to the triggering channel.

### DIFF
--- a/config/swagger.yml
+++ b/config/swagger.yml
@@ -94,6 +94,10 @@ paths:
                   in: formData
                   required: True
                   type: string
+                - name: response_url
+                  in: formData
+                  required: True
+                  type: string
             responses:
                 200:
                     description: Successfully authenticated.


### PR DESCRIPTION
The announce functions will still default to the specified channel in the .env file, but now allow for specifying the response URL in the arguments. This allows the announcement to specifically go to the channel that a triggering slash command originated from.